### PR TITLE
fix(sortedlist): 修复 All() 方法中因 nil 值导致的 panic 问题

### DIFF
--- a/pkg/sortedlist/list.go
+++ b/pkg/sortedlist/list.go
@@ -290,7 +290,7 @@ func (t *avlNode) height() int {
 func appendValue(values []interface{}, lower, upper int64, t *avlNode) []interface{} {
 	if t != nil {
 		values = appendValue(values, lower, upper, t.left)
-		if t.key >= lower && t.key <= upper {
+		if t.key >= lower && t.key <= upper && t.value != nil {
 			values = append(values, t.value)
 		}
 		values = appendValue(values, lower, upper, t.right)


### PR DESCRIPTION
#### 修复内容
在 `sortedlist` 包的 `appendValue` 函数中，修正了 `All` 方法初始化迭代器时将 `nil` 作为第一个元素添加到数据切片中，导致后续类型断言 `iter.Value().(Segment)` 时发生 panic 的问题。bug 来源于相关issue：https://github.com/chenjiandongx/mandodb/issues/3

#### 具体修改
将原先的条件判断：
```go
if t.key >= lower && t.key <= upper {
    values = append(values, t.value)
}
```

修改为：

```go
if t.key >= lower && t.key <= upper && t.value != nil {
    values = append(values, t.value)
}
```
确保只有非 nil 的值才会被添加到迭代器的数据切片中，从而避免类型断言时的 panic。
